### PR TITLE
Remove stale workaround for RT #127858

### DIFF
--- a/lib/OO/Monitors.pm6
+++ b/lib/OO/Monitors.pm6
@@ -20,7 +20,6 @@ class MetamodelX::MonitorHOW is Metamodel::ClassHOW {
     }
 
     method add_method(Mu \type, $name, $meth) {
-        my &callsame := CORE::<&callsame>; # Workaround for RT #127858
         $name ne 'BUILDALL' && $meth.wrap(-> \SELF, | {
             if SELF.DEFINITE {
                 # Instance method call; acquire lock.


### PR DESCRIPTION
The RT issue was moved to https://github.com/Raku/old-issue-tracker/issues/5221 and marked as resolved back in 2017. Although the fix [was later reverted](https://github.com/rakudo/rakudo/commit/50d38a1f368f0addb601e857232642f3a8de3aa2), it seems like this is no longer an issue, which suggests that this workaround can be removed.